### PR TITLE
Bug/mobile: Menu won't open on mobile device

### DIFF
--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -8,6 +8,11 @@ import './Navbar.scss';
 const Navbar = () => {
   const [toggle, setToggle] = useState(false);
 
+  const handleOnClick = (e) => {
+    e.stopPropagation();
+    setToggle((prevState) => !prevState);
+  };
+
   return (
     <nav className="app__navbar">
       <div className="app__navbar-logo">
@@ -23,14 +28,21 @@ const Navbar = () => {
       </ul>
 
       <div className="app__navbar-menu">
-        <HiMenuAlt4 onClick={() => setToggle(true)} />
+        <HiMenuAlt4 onClick={(e) => handleOnClick(e)} />
 
         {toggle && (
           <motion.div
-            whileInView={{ x: [300, 0] }}
+            initial={{ width: 0 }}
+            animate={{ width: 300 }}
             transition={{ duration: 0.85, ease: 'easeOut' }}
           >
-            <HiX onClick={() => setToggle(false)} />
+            <motion.span
+              initial={{ width: 0 }}
+              animate={{ width: 70 }}
+              transition={{ duration: 0.85, ease: 'easeOut' }}
+            >
+              <HiX onClick={(e) => handleOnClick(e)} />
+            </motion.span>
             <ul>
               {['home', 'about', 'work', 'skills', 'contact'].map((item) => (
                 <li key={item}>


### PR DESCRIPTION
Case: menu won't open on real mobile device because of event propagation
https://user-images.githubusercontent.com/33187294/155104106-034af928-a04b-4272-a469-ae4e5907efd1.mp4
Solution: 
- Prevented that with e.preventPropagation()
- Changed animation for menu div because on click, in a split second showing full div and after that start with animation


