### PR TITLE
Update Skills.scss: React-tooltip upgrade v4 to v5

### DIFF
--- a/src/container/Skills/Skills.scss
+++ b/src/container/Skills/Skills.scss
@@ -7,7 +7,6 @@
 .app__skills-container {
   width: 80%;
   margin-top: 3rem;
-
   display: flex;
   flex-direction: row;
 
@@ -23,7 +22,6 @@
   flex-wrap: wrap;
   justify-content: flex-start;
   align-items: flex-start;
-
   margin-right: 5rem;
 
   @media screen and (max-width: 900px) {
@@ -36,9 +34,7 @@
 .app__skills-item {
   flex-direction: column;
   text-align: center;
-
   margin: 1rem;
-
   transition: all 0.3s ease-in-out;
 
   div {
@@ -48,14 +44,13 @@
     background-color: #fef4f5;
 
     img {
-      width: 50%;
-      height: 50%;
+      width: 60%;
+      height: 60%;
     }
 
     &:hover {
       box-shadow: 0 0 25px #fef4f5;
     }
-
     @media screen and (min-width: 2000px) {
       width: 150px;
       height: 150px;
@@ -66,12 +61,10 @@
       height: 70px;
     }
   }
-
   p {
     font-weight: 500;
     margin-top: 0.5rem;
   }
-
   @media screen and (min-width: 2000px) {
     margin: 1rem 2rem;
 
@@ -102,24 +95,22 @@
   margin: 1rem 0;
 }
 
-.app__skills-exp-works {
+.app__skills-exp-woks {
   flex: 1;
-
   .app__skills-exp-work {
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
     align-items: flex-start;
     margin-bottom: 1rem;
-    cursor: pointer;
 
     h4 {
       font-weight: 500;
     }
 
     p {
-      font-weight: 400;
       color: var(--gray-color);
+      font-weight: 400;
       margin-top: 5px;
     }
   }
@@ -127,31 +118,28 @@
 
 .app__skills-exp-year {
   margin-right: 3rem;
-
-  p {
+  P {
     font-weight: 800;
     color: var(--secondary-color);
   }
-
   @media screen and (max-width: 450px) {
     margin-right: 1rem;
   }
 }
 
-.skills-tooltip {
-  max-width: 300px !important;
-  background-color: var(--white-color) !important;
-  box-shadow: 0 0 25px rgba(0, 0, 0, 0.1) !important;
-  border-radius: 5px !important;
-  padding: 1rem !important;
-  color: var(--gray-color) !important;
-  text-align: center !important;
-  line-height: 1.5 !important;
-  opacity: 1 !important;
-
+.app__skills-tooltip .skills-tooltip {
+  max-width: 300px;
+  background-color: var(--white-color);
+  box-shadow: 0 0 25px rgba(0, 0, 0, 0.1);
+  border-radius: 5px;
+  color: var(--gray-color);
+  padding: 1rem;
+  text-align: center;
+  line-height: 1.5;
+  opacity: 1;
   @media screen and (min-width: 2000px) {
-    font-size: 1.75rem !important;
-    max-width: 500px !important;
-    line-height: 2 !important;
+    font-size: 1.75rem;
+    max-width: 500px;
+    line-height: 2;
   }
 }


### PR DESCRIPTION
upgrading the React-tooltip v4 to v5 in v5 don't need to use !important to override the styles, need to use the CSS Specificity instead