### PR TITLE
ReactTooltip not displaying - my resolution

### DIFF
--- a/src/container/Skills/Skills.jsx
+++ b/src/container/Skills/Skills.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import ReactTooltip from 'react-tooltip';
+import { Tooltip as ReactTooltip } from 'react-tooltip';
 
 import { AppWrap, MotionWrap } from '../../wrapper';
 import { urlFor, client } from '../../client';
@@ -66,10 +66,11 @@ const Skills = () => {
                       data-for={work.name}
                       key={work.name}
                     >
-                      <h4 className="bold-text">{work.name}</h4>
+                      <h4 className="bold-text" id={work.name.replace(/\s/g, "")}>{work.name}</h4>
                       <p className="p-text">{work.company}</p>
                     </motion.div>
                     <ReactTooltip
+                      anchorSelect={'#' + work.name.replace(/\s/g, "")}
                       id={work.name}
                       effect="solid"
                       arrowColor="#fff"


### PR DESCRIPTION
When running through the YouTube tutorial my ReactTooltips in `Skills.jsx` were not displaying. The solution for me was to add an `id` property to the `h4` tag displaying `work.name`, and then reference it using the `anchorSelect` property of the ReactTooltip tag.

Also need to change the import to `import { Tooltip as ReactTooltip } from 'react-tooltip';` to resolve the error:
```
export 'default' (imported as 'ReactTooltip') was not found in 'react-tooltip' (possible exports: Tooltip, TooltipProvider, TooltipWrapper, removeStyle)
```