### PR TITLE
small screen displaying single column for all content: skill, about, and work sections 

### DIFF
--- a/src/wrapper/MotionWrap.js
+++ b/src/wrapper/MotionWrap.js
@@ -6,7 +6,7 @@ const MotionWrap = (Component, classNames) => function HOC() {
     <motion.div
       whileInView={{ y: [100, 50, 0], opacity: [0, 0, 1] }}
       transition={{ duration: 0.5 }}
-      className={`${classNames} app__flex`}
+      className={`${classNames} app__container app__wrapper app__flex`}
     >
       <Component />
     </motion.div>


### PR DESCRIPTION
fix the unresponsiveness of each section on small screens
expected behavior of displaying content in a column not applying
all elements are displayed as one column and the header as a separate column